### PR TITLE
Feat: Use user's Vite config for client build

### DIFF
--- a/core/build.js
+++ b/core/build.js
@@ -3,17 +3,19 @@ const replace = require('@rollup/plugin-replace')
 const path = require('path')
 const mergeOptions = require('merge-options').bind({ concatArrays: true })
 const plugin = require('./plugin')
-const { getEntryPoint } = require('./config')
+const { resolveViteConfig, getEntryPoint } = require('./config')
 
 const [name] = Object.keys(plugin.alias)
 
 module.exports = async ({ clientOptions = {}, ssrOptions = {} } = {}) => {
+  const viteConfig = await resolveViteConfig()
   const clientResult = await build(
     mergeOptions(
       {
         outDir: path.resolve(process.cwd(), 'dist/client'),
         alias: plugin.alias,
       },
+      viteConfig,
       clientOptions
     )
   )

--- a/core/build.js
+++ b/core/build.js
@@ -12,11 +12,11 @@ module.exports = async ({ clientOptions = {}, ssrOptions = {} } = {}) => {
   const viteConfig = await resolveViteConfig()
   const clientResult = await build(
     mergeOptions(
+      viteConfig,
       {
         outDir: path.resolve(process.cwd(), 'dist/client'),
         alias: plugin.alias,
       },
-      viteConfig,
       clientOptions
     )
   )
@@ -27,6 +27,7 @@ module.exports = async ({ clientOptions = {}, ssrOptions = {} } = {}) => {
 
   await ssrBuild(
     mergeOptions(
+      viteConfig,
       {
         outDir: ssrOutDirPath,
         assetsDir: '',

--- a/core/config.js
+++ b/core/config.js
@@ -1,5 +1,6 @@
 const fs = require('fs').promises
 const path = require('path')
+const { resolveConfig } = require('vite')
 
 const viteConfigJS = 'vite.config.js'
 const viteConfigTS = 'vite.config.ts'
@@ -57,4 +58,12 @@ exports.getEntryPoint = async function () {
   const entryFile = matches[1] || 'src/main'
 
   return path.join(rootDir, entryFile)
+}
+
+exports.resolveViteConfig = async function (mode) {
+  const { rootDir, configFileName } = await await exports.getProjectInfo()
+  return resolveConfig(
+    mode || process.env.MODE || process.env.NODE_ENV,
+    path.join(rootDir, configFileName)
+  )
 }

--- a/core/config.js
+++ b/core/config.js
@@ -61,7 +61,7 @@ exports.getEntryPoint = async function () {
 }
 
 exports.resolveViteConfig = async function (mode) {
-  const { rootDir, configFileName } = await await exports.getProjectInfo()
+  const { rootDir, configFileName } = exports.getProjectInfo()
   return resolveConfig(
     mode || process.env.MODE || process.env.NODE_ENV,
     path.join(rootDir, configFileName)


### PR DESCRIPTION
Blocked by:
- https://github.com/vitejs/vite/pull/1165
- https://github.com/vitejs/vite/issues/1166

-- Edit:
Added some patches to Vite using [Vitedge CLI](https://github.com/frandiox/vitedge/blob/master/core/bin/cli.js#L18).
Without these patches, resolving the user config will fail if it has `.ts` extension.