### PR TITLE
feat: expose `Context` type

### DIFF
--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,2 +1,3 @@
 export * from './entry-client'
 export { default } from './entry-client'
+export type { Context } from './types'

--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -1,2 +1,3 @@
 export * from './entry-client'
 export { default } from './entry-client'
+export type { Context } from './types'


### PR DESCRIPTION
It allows to import `Context` type for use at places where `useContext` can't be used (e.g. outside of components/`setup()`).
I need this to implement modules which need the current context.

Example:
`src/main.ts`
```ts
export default viteSSR(
  App,
  { routes },
  (context) => {
    // Install modules
   Object.values(import.meta.globEager('./modules/*.ts')).map(i => i.default?.(context))   
  }
)
```
`src/modules/foo.ts`
```ts
// this can't be injected because it's outside of setup()
import { useContext } from 'vite-ssr/vue'

// solution: pass context from entry to each module function
import type { Context } from 'vite-ssr/vue'

export default ({ app }: Context) => {
  /* ... */
  app.use(...)
}
```