### PR TITLE
feat: add build.keepIndexHtml plugin option

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,29 @@ createServer()
 
 Run `vite-ssr build` for buildling your app. This will create 2 builds (client and server) that you can import and use from your Node backend. See an Express.js example server [here](./examples/node-server/index.js), or a serverless function deployed to Vercel [here](https://github.com/frandiox/vitesse-ssr-template/blob/master/serverless/api/index.js).
 
+<details><summary>Keeping index.html in the client build</summary>
+<p>
+
+In an SSR app, `index.html` is already embedded in the server build, and is thus removed from the client build in order to prevent serving it by mistake. However, if you would like to keep `index.html` in the client build (e.g. when using server side routing to selectively use SSR for a subset of routes), you can set `build.keepIndexHtml` to `true` in the plugin options:
+
+```js
+// vite.config.js
+
+export default {
+  plugins: [
+    viteSSR({
+      build: {
+        keepIndexHtml: true,
+      },
+    }),
+    [...]
+  ],
+}
+```
+
+</p>
+</details>
+
 ## Integrations
 
 Common integrations will be added here:

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -6,6 +6,13 @@ const entryServer = '/entry-server'
 const entryClient = '/entry-client'
 
 type ViteSsrPluginOptions = {
+  build?: {
+    /**
+     * Keep the index.html generated in the client build
+     * @default false
+     */
+    keepIndexHtml?: boolean
+  },
   features?: {
     /**
      * Use '@apollo/client' renderer if present
@@ -20,6 +27,7 @@ export = function ViteSsrPlugin(
 ) {
   return {
     name: pluginName,
+    buildOptions: options.build || {},
     config() {
       let isReact = false
 


### PR DESCRIPTION
Closes #70.

`vite-ssr build` removes `index.html` from the client bundle to prevent serving it by mistake in an SSR app.

However, there may be use cases where `index.html` should be preserved in the client build (e.g. when using server side routing to selectively use SSR for a subset of routes).

Let's provide a plugin option `build.keepIndexHtml` so that a user can keep `index.html` in the client bundle if desired.