### PR TITLE
feat: add router to vue context

### DIFF
--- a/src/vue/entry-client.ts
+++ b/src/vue/entry-client.ts
@@ -64,6 +64,7 @@ export const viteSSR: ClientHandler = async function viteSSR(
     initialState: initialState || {},
     writeResponse,
     redirect,
+    router,
   } as Context
 
   provideContext(app, context)

--- a/src/vue/entry-server.ts
+++ b/src/vue/entry-server.ts
@@ -47,6 +47,7 @@ export const viteSSR: SsrHandler = function viteSSR(
       isClient: false,
       initialState: {},
       redirect,
+      router,
       writeResponse,
       ...extra,
     } as Context

--- a/src/vue/types.ts
+++ b/src/vue/types.ts
@@ -32,7 +32,9 @@ type HookResponse = void | {
   head?: HeadClient
 }
 
-export type Context = SharedContext
+export type Context = SharedContext & {
+  router: Router
+}
 
 export type HookParams = Context & {
   app: App


### PR DESCRIPTION
Since the react implementation is already return the router instance on the context object, I've adapted these changes to vue.