### PR TITLE
fix: Leaner state serialization to JSON

### DIFF
--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -1,8 +1,9 @@
 // https://github.com/yahoo/serialize-javascript
-const UNSAFE_CHARS_REGEXP = /[<>\/\u2028\u2029]/g
+const UNSAFE_CHARS_REGEXP = /[<>'\/\u2028\u2029]/g
 const ESCAPED_CHARS = {
   '<': '\\u003C',
   '>': '\\u003E',
+  '\'': '\\\'',
   '/': '\\u002F',
   '\u2028': '\\u2028',
   '\u2029': '\\u2029',
@@ -14,10 +15,11 @@ function escapeUnsafeChars(unsafeChar: string) {
 
 export function serializeState(state: any) {
   try {
-    return JSON.stringify(JSON.stringify(state || {})).replace(
+    // Wrap the serialized JSON in quotes so that it's parsed by the browser as a string for better performance.
+    return `'${JSON.stringify(state || {}).replace(
       UNSAFE_CHARS_REGEXP,
       escapeUnsafeChars
-    )
+    )}'`
   } catch (error) {
     console.error('[SSR] On state serialization -', error, state)
     return '{}'

--- a/test/specs/utils/state.spec.ts
+++ b/test/specs/utils/state.spec.ts
@@ -1,0 +1,17 @@
+import { test } from 'uvu'
+import * as assert from 'uvu/assert'
+import { serializeState } from '../../../src/utils/state';
+
+test('serializeState', () => {
+  // Simple case.
+  assert.is(serializeState({}), `'{}'`)
+
+  // Expect double quotes not to be needlessly escaped.
+  assert.is(serializeState({ hello: 'world' }), `'{"hello":"world"}'`)
+
+  // Expect single quotes to be escaped.
+  assert.is(serializeState({ quote: `'` }), `'{"quote":"\\'"}'`)
+
+  // Expect angle brackets to be escaped.
+  assert.is(serializeState({ brackets: `< >` }), `'{"brackets":"\\u003C \\u003E"}'`)
+});


### PR DESCRIPTION
Fixes https://github.com/frandiox/vite-ssr/issues/97

Instead of double JSON-stringifying, which can add _a lot_ of `\` characters to escape double quotes (because JSON tends to have lots of double quotes, for every property name and string), serialize state as a JSON object wrapped in single quotes.