### PR TITLE
fix: Split utils/state.ts into utils/serialize-state.ts & utils/deserialize-state.ts. Closes #118

### DIFF
--- a/src/core/entry-client.ts
+++ b/src/core/entry-client.ts
@@ -1,4 +1,4 @@
-import { deserializeState } from '../utils/state'
+import { deserializeState } from '../utils/deserialize-state'
 import { useClientRedirect } from '../utils/response'
 import type { ClientHandler, Context, Options } from './types'
 

--- a/src/core/entry-server.ts
+++ b/src/core/entry-server.ts
@@ -1,6 +1,6 @@
 import { createUrl } from '../utils/route'
 import { useSsrResponse } from '../utils/response'
-import { serializeState } from '../utils/state'
+import { serializeState } from '../utils/serialize-state'
 import {
   buildHtmlDocument,
   findDependencies,

--- a/src/utils/deserialize-state.ts
+++ b/src/utils/deserialize-state.ts
@@ -1,0 +1,8 @@
+export function deserializeState(state: string) {
+  try {
+    return JSON.parse(state || '{}')
+  } catch (error) {
+    console.error('[SSR] On state deserialization -', error, state)
+    return {}
+  }
+}

--- a/src/utils/serialize-state.ts
+++ b/src/utils/serialize-state.ts
@@ -34,12 +34,3 @@ export function serializeState(state: any) {
     return '{}'
   }
 }
-
-export function deserializeState(state: string) {
-  try {
-    return JSON.parse(state || '{}')
-  } catch (error) {
-    console.error('[SSR] On state deserialization -', error, state)
-    return {}
-  }
-}

--- a/test/specs/utils/state.spec.ts
+++ b/test/specs/utils/state.spec.ts
@@ -1,6 +1,6 @@
 import { test } from 'uvu'
 import * as assert from 'uvu/assert'
-import { serializeState } from '../../../src/utils/state'
+import { serializeState } from '../../../src/utils/serialize-state'
 
 test('serializeState', () => {
   // Simple case.


### PR DESCRIPTION
~~This PR replaces regexes to use lookahead expressions instead of lookbehind expressions.  ~~

~~Safari considers lookbehind regexes are invalid, so current serializeState method raises SyntaxError. So, to fix the problem, regexes without lookbehind expressions are required.~~

Safari considers lookbehind regexes are invalid, so current serializeState method raises SyntaxError.
Split `state.ts` into two files: `serialize-state.ts` and `deserialize-state.ts`, and use `serialize-state.ts` in `entry-server.ts`, and use `deserialize-state.ts` in `entry-client.ts`