### PR TITLE
Enable hydration for Vue apps

### DIFF
--- a/src/vue/entry-client.ts
+++ b/src/vue/entry-client.ts
@@ -1,4 +1,4 @@
-import { createApp } from 'vue'
+import { createSSRApp } from 'vue'
 import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router'
 import createClientContext from '../core/entry-client.js'
 import { getFullPath, withoutSuffix } from '../utils/route'
@@ -24,7 +24,7 @@ export const viteSSR: ClientHandler = async function viteSSR(
     addPagePropsGetterToRoutes(routes)
   }
 
-  const app = createApp(App)
+  const app = createSSRApp(App)
 
   const url = window.location
   const routeBase = base && withoutSuffix(base({ url }), '/')


### PR DESCRIPTION
Right now Vue apps are not hydrated on a client due to a `createApp` used in a client bundle, instead of `createSSRApp`. The latter is what enables hyration on a client.

To verify this set a breakpoint in a `e.isMounted` else condition in a vendor chunk here: https://vercelvitessr.vercel.app/ (this site is using vite-ssr).

![image](https://user-images.githubusercontent.com/1462706/146611851-777958bf-7044-44f2-b8c4-64743dd84eff.png)

Then check how the DOM looks when it triggers.

After the change the hydration should work as expected.
