### PR TITLE
fix: backslash escaping

### DIFF
--- a/src/utils/serialize-state.ts
+++ b/src/utils/serialize-state.ts
@@ -20,9 +20,11 @@ export function serializeState(state: any) {
 
     state = JSON.stringify(state || {})
       // 1. Duplicate the escape char (\) for already escaped characters (e.g. \n or \").
-      .replace(/(?<!\\)\\(.)/g, '\\\\$1')
+      .replace(/\\/g, String.raw`\\`)
       // 2. Escape existing single quotes to allow wrapping the whole thing in '...'.
-      .replace(/(?<!\\)'/g, "\\'")
+      // Because we are doing the JSON.stringify ourselves (i.e., we're not taking a JSON string as a parameter, in
+      // which case we wouldn't know if there is redundant escaping), it's safe to use a regular expression for this.
+      .replace(/'/g, String.raw`\'`)
       // 3. Escape unsafe chars.
       .replace(UNSAFE_CHARS_REGEXP, escapeUnsafeChars)
 

--- a/test/specs/utils/state.spec.ts
+++ b/test/specs/utils/state.spec.ts
@@ -18,6 +18,23 @@ test('serializeState', () => {
   // Expect single quotes to be escaped.
   assert.is(serializeState({ quote: `'` }), `'{"quote":"\\'"}'`)
 
+  // Expect escape characters to be escaped.
+  // In our object, the "esc" property is a string with one character: a backslash.
+  // As JSON, that object is: {"esc":"\\"}
+  // Then, when that JSON string is wrapped in single quotes, it becomes: '{"esc":"\\\\"}'
+  // That is, each backslash is escaped.
+  assert.is(serializeState({ esc: '\\' }), String.raw`'{"esc":"\\\\"}'`)
+  // Note that:
+  assert.is(String.raw`'{"esc":"\\\\"}'`, `'{"esc":"\\\\\\\\"}'`)
+
+  // Expect nested JSON strings to be correctly escaped.
+  assert.is(
+    serializeState({
+      text: JSON.stringify({ insert: '\n' }),
+    }),
+    String.raw`'{"text":"{\\"insert\\":\\"\\\\n\\"}"}'`
+  )
+
   // Expect angle brackets to be escaped.
   assert.is(
     serializeState({ brackets: `< >` }),


### PR DESCRIPTION
There is a bug in the way escaping is done on the JSON serialized state: the code is seemingly trying to not add extra escape characters but turns out to produce invalid JSON anytime there's a nested JSON string containing an escape character. This was causing an error when the page loaded, and the __INITIAL_STATE__ was discarded. (More precisely, there's a missing backslash in every nested JSON string containing an escaped character.)

This PR fixes that bug. The thing to understand is that escaping should be simple and, in a sense, "dumb" — the proposed code in this PR simply takes the JSON-stringified state object and doubles up each backslash character. It really is as simple as that, and any attempt to use regex to check where an escape character may not be needed will necessarily be buggy because it wouldn't be able to account for arbitrarily deeply nested JSON.

Similarly, I'm simplifying the escaping of single quotes in the same way: When we've JSON-stringified the state object, the JSON will not contain any escaped single quotes because `JSON.stringify` doesn't escape single quotes. Note that _runtime strings_ don't have any escaping... escaping is used only when _representing_ a string in code. So escaping the single quotes in our JSON string is simply a matter of replacing each `'` with a `\'`.

Besides adding tests, I've manually tested these changes in my project and it works.