### PR TITLE
fix: missing Content-Type header for HTML in express server example

### DIFF
--- a/examples/node-server/index.js
+++ b/examples/node-server/index.js
@@ -53,6 +53,7 @@ server.get('*', async (request, response) => {
     // initialState: { ... } // <- This would also be available
   })
 
+  response.type('html')
   response.writeHead(status || 200, statusText || headers, headers)
   response.end(html)
 })


### PR DESCRIPTION
## Summary

Basically, the following two code snippets works differently when dealing with the HTTP header `Content-Type`:

```javascript
const { html, status, statusText, headers } = await renderPage(url, {
    manifest,
    preload: true,
    // Anything passed here will be available in the main hook
    request,
    response,
    // initialState: { ... } // <- This would also be available
  })

  response.writeHead(status || 200, statusText || headers, headers)
  response.end(html)
```

```javascript
server.use(
    '/' + asset,
    express.static(path.join(__dirname, `${dist}/client/` + asset))
  )
```

Express won't auto detect and set `Content-Type` for the actual content `html` in the first code snippet, where `express.static(...)` will handle the `Content-Type` header for each individual assets correctly in the second code snippet.

And as for another security issue involved scenario, where we will need the `X-Content-Type-Options` header set to `nosniff` present for each request in order to prevent MIME type attacks, reference:

> These vulnerabilities can occur when a website allows users to upload content to a website however the user disguises a particular file type as something else. This can give them the opportunity to perform cross-site scripting and compromise the website.

> However, this security header helps prevent these types of attacks by disabling the MIME sniffing functionality of IE and Chrome browsers so that the browser is required to use the MIME type sent via the origin server. Consider the following example of how `X-Content-Type-Options` works for a particular web request.

Whether or not the `X-Content-Type-Options` header present, the server should always set the `Content-Type` header correctly. Therefore we need to set the `Content-Type` explicitly, which is this PR's meaning here.

## References

[X-Content-Type-Options header - MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options)
[X-Content-Type-Options HTTP Header - KeyCDN Support](https://www.keycdn.com/support/x-content-type-options
)