### PR TITLE
Fix generated `package.json` during build

### DIFF
--- a/examples/react-apollo/vite.config.js
+++ b/examples/react-apollo/vite.config.js
@@ -4,6 +4,7 @@ const viteSSR = require('vite-ssr/plugin')
 const api = require('../node-server/api')
 
 module.exports = defineConfig({
+  ssr: { format: 'cjs' },
   plugins: [
     viteSSR(),
     react(),

--- a/examples/react/vite.config.js
+++ b/examples/react/vite.config.js
@@ -10,6 +10,7 @@ module.exports = defineConfig({
       strict: false,
     },
   },
+  ssr: { format: 'cjs' },
   plugins: [
     viteSSR({
       features: {

--- a/examples/vanilla/src/entry-server.js
+++ b/examples/vanilla/src/entry-server.js
@@ -3,7 +3,7 @@ import viteSSR from 'vite-ssr/core/entry-server'
 import { html } from './utils'
 
 // These are pages following a custom format:
-const pageModules = import.meta.globEager('./pages/**/*.js')
+const pageModules = import.meta.glob('./pages/**/*.js', { eager: true })
 
 // Simple server-only router (i.e. this is not an SPA!):
 const serverRouter = new Map()

--- a/examples/vue/vite.config.js
+++ b/examples/vue/vite.config.js
@@ -10,6 +10,7 @@ module.exports = defineConfig({
       strict: false,
     },
   },
+  ssr: { format: 'cjs' },
   plugins: [
     viteSSR(),
     vue(),

--- a/test/fixtures/react-ts-basic/vite.config.js
+++ b/test/fixtures/react-ts-basic/vite.config.js
@@ -4,6 +4,7 @@ const viteSSR = require('vite-ssr/plugin')
 
 // https://vitejs.dev/config/
 module.exports = defineConfig({
+  ssr: { format: 'cjs' },
   plugins: [
     viteSSR({
       features: {

--- a/test/fixtures/vue-ts-basic/vite.config.js
+++ b/test/fixtures/vue-ts-basic/vite.config.js
@@ -4,5 +4,6 @@ const viteSSR = require('vite-ssr/plugin')
 
 // https://vitejs.dev/config/
 module.exports = defineConfig({
+  ssr: { format: 'cjs' },
   plugins: [viteSSR(), vue()],
 })


### PR DESCRIPTION
Vite 3+ defaults to ESM and we need to consider this when writing the `package.json` file.