### PR TITLE
docs: update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Then, add `vite-ssr` with your package manager (direct dependency) and your fram
 
 ```sh
 # For Vue
-yarn add vite-ssr vue@3 vue-router@4 @vueuse/head
+yarn add vite-ssr vue@3 vue-router@4 @vueuse/head@^0.9.0
 
 # For React
 yarn add vite-ssr react@16 react-router-dom@5


### PR DESCRIPTION
Correctly explain what version of @vueuse/head should be installed. A higher version if this package will not work in SSR mode.

Possibly another PR should be created to support the newest version of the package.