### PR TITLE
fix: __DEV__ build conflict (fix #221)

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -40,7 +40,7 @@ export = function ViteSsrPlugin(
             __CONTAINER_ID__: JSON.stringify(options.containerId || 'app'),
             // Vite 2.6.0 bug: use this
             // instead of import.meta.env.DEV
-            __DEV__: env.mode !== 'production',
+            __VITE_SSR_DEV__: env.mode !== 'production',
           },
           ssr: {
             ...detectedFeats.ssr,

--- a/src/react/entry-client.ts
+++ b/src/react/entry-client.ts
@@ -76,7 +76,7 @@ export const viteSSR: ClientHandler = async function (
     styles && styles.cleanup && styles.cleanup()
 
     // @ts-ignore
-    __DEV__ ? ReactDOM.render(app, el) : ReactDOM.hydrate(app, el)
+    __VITE_SSR_DEV__ ? ReactDOM.render(app, el) : ReactDOM.hydrate(app, el)
   }
 }
 

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -47,7 +47,7 @@ export function buildHtmlDocument(
   { htmlAttrs, bodyAttrs, headTags, body, initialState }: DocParts
 ) {
   // @ts-ignore
-  if (__DEV__) {
+  if (__VITE_SSR_DEV__) {
     if (template.indexOf(`id="${containerId}"`) === -1) {
       console.warn(
         `[SSR] Container with id "${containerId}" was not found in index.html`

--- a/test/setup/globals.ts
+++ b/test/setup/globals.ts
@@ -1,5 +1,5 @@
 const globals = {
-  __DEV__: false,
+  __VITE_SSR_DEV__: false,
   __CONTAINER_ID__: 'app',
 }
 


### PR DESCRIPTION
Issue: https://github.com/frandiox/vite-ssr/issues/221

Using `__DEV__` in a few places causes error during production build if another package also uses that variable name, as the build replaces `__DEV__` with false in the other package. Renaming the variable used in vite-ssr avoids this conflict

For example, see this error:
```
[commonjs--resolver] Unexpected keyword 'false' (55:5) in C:/Snaps/pwp/pwp-ui/node_modules/@carbon/react/es/components/ModalWrapper/ModalWrapper.js
file: node_modules/@carbon/react/es/components/ModalWrapper/ModalWrapper.js:55:5
55:   if(false) {
```